### PR TITLE
Requires python3-dev v3.7.7-r1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk --update \
         libc-dev=0.7.1-r0 \
         libressl-dev=2.7.5-r0 \
         libffi-dev=3.2.1-r6 \
-        python3-dev=3.7.5-r1
+        python3-dev=3.7.7-r1
 
 WORKDIR /app
 


### PR DESCRIPTION
Alpine 3.10 is now providing python3-dev-3.7.7-r1.
https://pkgs.alpinelinux.org/packages?name=python3-dev&branch=v3.10&arch=x86_64

I got the following error.
```
ERROR: unsatisfiable constraints:
    python3-dev-3.7.7-r1:
      breaks: build_dependencies-20200813.061343[python3-dev=3.7.5-r1]
  The command '/bin/sh -c apk --update     add --no-cache --virtual build_dependencies         alpine-sdk=1.0-r0         libc-dev=0.7.1-r0         libressl-dev=2.7.5-r0         libffi-dev=3.2.1-r6         python3-dev=3.7.5-r1' returned a non-zero code: 2
```